### PR TITLE
QE-356 Manual type mapping override

### DIFF
--- a/datamodel_code_generator/model/pydantic/__init__.py
+++ b/datamodel_code_generator/model/pydantic/__init__.py
@@ -9,7 +9,6 @@ from .types import DataTypeManager
 
 
 def dump_resolve_reference_action(class_names: Iterable[str]) -> str:
-    import pdb; pdb.set_trace()
     return '\n'.join(
         f'{class_name}.update_forward_refs()' for class_name in class_names
     )

--- a/datamodel_code_generator/model/pydantic/__init__.py
+++ b/datamodel_code_generator/model/pydantic/__init__.py
@@ -9,6 +9,7 @@ from .types import DataTypeManager
 
 
 def dump_resolve_reference_action(class_names: Iterable[str]) -> str:
+    import pdb; pdb.set_trace()
     return '\n'.join(
         f'{class_name}.update_forward_refs()' for class_name in class_names
     )

--- a/datamodel_code_generator/model/schematics/mapping.py
+++ b/datamodel_code_generator/model/schematics/mapping.py
@@ -5,6 +5,6 @@
 NAME_OVERRIDE_MAPPING = {
     'AppetiteEligibilityAnswer': {
         # subQuestions calls a circular reference possibly infinitely, and schematics doesn't support forward references
-        'subQuestions': 'ListType(BaseType(), serialized_name=\'subQuestions\')'}
+        'subQuestions': "ListType(BaseType(), serialized_name='subQuestions)"}
 
 }

--- a/datamodel_code_generator/model/schematics/mapping.py
+++ b/datamodel_code_generator/model/schematics/mapping.py
@@ -5,6 +5,6 @@
 NAME_OVERRIDE_MAPPING = {
     'AppetiteEligibilityAnswer': {
         # subQuestions calls a circular reference possibly infinitely, and schematics doesn't support forward references
-        'subQuestions': "ListType(BaseType(), serialized_name='subQuestions)"}
+        'subQuestions': "ListType(BaseType(), serialized_name='subQuestions')"}
 
 }

--- a/datamodel_code_generator/model/schematics/mapping.py
+++ b/datamodel_code_generator/model/schematics/mapping.py
@@ -1,0 +1,10 @@
+# This mapping is a workaround for any specific fields which end up being too difficult to map
+# Try to include a comment as to each field if you modify this describing why the type should be
+# overridden that way code reviewers can examine to see if it's an appropriate use case for this file.
+
+NAME_OVERRIDE_MAPPING = {
+    'AppetiteEligibilityAnswer': {
+        # subQuestions calls a circular reference possibly infinitely, and schematics doesn't support forward references
+        'subQuestions': 'ListType(BaseType(), serialized_name=\'subQuestions\')'}
+
+}

--- a/datamodel_code_generator/model/schematics/schematics_model_field.py
+++ b/datamodel_code_generator/model/schematics/schematics_model_field.py
@@ -8,6 +8,7 @@ from datamodel_code_generator.model.base import DataModelFieldBase
 from datamodel_code_generator.model.schematics.base_model import BaseModel
 from datamodel_code_generator.model.schematics.custom_root_type import CustomRootType
 from datamodel_code_generator.model.schematics.imports import IMPORT_MODEL, IMPORT_LIST, IMPORT_DICT, IMPORT_ANY
+from datamodel_code_generator.model.schematics.mapping import NAME_OVERRIDE_MAPPING
 from datamodel_code_generator.types import chain_as_tuple, DataType
 
 
@@ -91,7 +92,10 @@ class SchematicsModelField(DataModelFieldBase):
                 outer = sublist[0]
                 is_model_type = outer.reference is not None
 
-                # Is model type if reference attr exists
+                # Short circuit with pre-defined mappings
+                if self.name in NAME_OVERRIDE_MAPPING.get(self.parent.name, {}):
+                    # Gets a list of specific fields to override
+                    return NAME_OVERRIDE_MAPPING[self.parent.name][self.name]
 
                 if outer.is_list:
                     outer_type = 'ListType'

--- a/datamodel_code_generator/parser/base.py
+++ b/datamodel_code_generator/parser/base.py
@@ -269,7 +269,7 @@ class Parser(ABC):
         self.results: List[DataModel] = []
         self.dump_resolve_reference_action: Optional[
             Callable[[Iterable[str]], str]
-        ] = dump_resolve_reference_action
+        ] = None if self.is_using_schematics else dump_resolve_reference_action
         self.validation: bool = validation
         self.field_constraints: bool = field_constraints
         self.snake_case_field: bool = snake_case_field


### PR DESCRIPTION
Adds a workaround for manually overriding specific types when they're impossible or too difficult to implement inside of datamodel codegen 