### PR TITLE
Eligibility answers inputs

### DIFF
--- a/datamodel_code_generator/model/schematics/mapping.py
+++ b/datamodel_code_generator/model/schematics/mapping.py
@@ -5,6 +5,9 @@
 NAME_OVERRIDE_MAPPING = {
     'AppetiteEligibilityAnswer': {
         # subQuestions calls a circular reference possibly infinitely, and schematics doesn't support forward references
-        'subQuestions': "ListType(BaseType(), serialized_name='subQuestions')"}
+        'subQuestions': "ListType(BaseType(), serialized_name='subQuestions')"},
+    'PortalUserInputs': {
+        'eligibilityAnswers': "DictType(BaseType(required=False), serialized_name='eligibilityAnswers')"
+    }
 
 }

--- a/datamodel_code_generator/model/schematics/mapping.py
+++ b/datamodel_code_generator/model/schematics/mapping.py
@@ -7,6 +7,8 @@ NAME_OVERRIDE_MAPPING = {
         # subQuestions calls a circular reference possibly infinitely, and schematics doesn't support forward references
         'subQuestions': "ListType(BaseType(), serialized_name='subQuestions')"},
     'PortalUserInputs': {
+        # eligibilityAnswers uses `None` as an acceptable field, yet is required. Schematics has a builtin check to not
+        # accept None as a value unless required is False
         'eligibilityAnswers': "DictType(BaseType(required=False), serialized_name='eligibilityAnswers')"
     }
 


### PR DESCRIPTION
EligibilityAnswers uses `None` as an acceptable field, yet is required. Schematics has a builtin check to not accept None as a value unless required is False
